### PR TITLE
Fix bugs in interpolated string handling

### DIFF
--- a/src/Boo.Lang.Parser/BooLexer.g4
+++ b/src/Boo.Lang.Parser/BooLexer.g4
@@ -464,11 +464,11 @@ mode TQS;
 		;
 
 	TQS_INTERPOLATED_EXPRESSION_LBRACE
-		:	'${' {HandleInterpolatedExpression(LBRACE, RBRACE);} -> type(INTERPOLATED_EXPRESSION_LBRACE)
+		:	'${' {EnterSkipWhitespaceRegion(); HandleInterpolatedExpression(LBRACE, RBRACE);} -> type(INTERPOLATED_EXPRESSION_LBRACE)
 		;
 
 	TQS_INTERPOLATED_EXPRESSION_LPAREN
-		:	'$(' {HandleInterpolatedExpression(LPAREN, RPAREN);} -> type(INTERPOLATED_EXPRESSION_LPAREN)
+		:	'$(' {EnterSkipWhitespaceRegion(); HandleInterpolatedExpression(LPAREN, RPAREN);} -> type(INTERPOLATED_EXPRESSION_LPAREN)
 		;
 
 	TQS_STRAY_DOLLAR
@@ -503,11 +503,11 @@ mode DQS;
 		;
 
 	INTERPOLATED_EXPRESSION_LBRACE
-		:	'${' {HandleInterpolatedExpression(LBRACE, RBRACE);}
+		:	'${' {EnterSkipWhitespaceRegion(); HandleInterpolatedExpression(LBRACE, RBRACE);}
 		;
 
 	INTERPOLATED_EXPRESSION_LPAREN
-		:	'$(' {HandleInterpolatedExpression(LPAREN, RPAREN);}
+		:	'$(' {EnterSkipWhitespaceRegion(); HandleInterpolatedExpression(LPAREN, RPAREN);}
 		;
 
 	STRAY_DOLLAR

--- a/src/Boo.Lang.Parser/BooTokenV4.cs
+++ b/src/Boo.Lang.Parser/BooTokenV4.cs
@@ -54,10 +54,11 @@ namespace Boo.Lang.ParserV4
 		{
 		}
 
-		public BooTokenV4(int type, string text, string fname, int start, int stop, int line, int column, bool magic)
+		public BooTokenV4(Tuple<ITokenSource, ICharStream> source, int type, string text, string fname, int start, int stop, int line, int column, bool magic)
 			: base(type, text)
 		{
 			setFilename(fname);
+			this.source = source;
 			this.StartIndex = start;
 			this.StopIndex = stop;
 			this.Line = line;

--- a/src/Boo.Lang.Parser/Util/IndentTokenStreamFilterV4.cs
+++ b/src/Boo.Lang.Parser/Util/IndentTokenStreamFilterV4.cs
@@ -305,7 +305,7 @@ namespace Boo.Lang.Parser.Util
 
 		IToken CreateToken(IToken prototype, int newTokenType, string newTokenText)
 		{
-			return new BooTokenV4(newTokenType, newTokenText,
+			return new BooTokenV4(Tuple.Create(prototype.TokenSource, prototype.InputStream), newTokenType, newTokenText,
 				prototype.InputStream.SourceName,
 				prototype.StartIndex,
 				prototype.StartIndex - 1,

--- a/src/Boo.Lang.Parser/Util/WSATokenStreamFilterV4.cs
+++ b/src/Boo.Lang.Parser/Util/WSATokenStreamFilterV4.cs
@@ -302,7 +302,7 @@ namespace Boo.Lang.Parser.Util
 				
 		static IToken CreateToken(IToken prototype, int newTokenType, string newTokenText)
 		{
-			return new BooTokenV4(newTokenType, newTokenText,
+			return new BooTokenV4(Tuple.Create(prototype.TokenSource, prototype.InputStream), newTokenType, newTokenText,
 				prototype.InputStream.SourceName,
 				prototype.StartIndex,
 				prototype.StartIndex - 1,


### PR DESCRIPTION
- Make sure to set the source for manufactured tokens
- Fix unbalanced calls to `EnterSkipWhitespaceRegion`/`LeaveSkipWhitespaceRegion` following an interpolated string
