### PR TITLE
Fixing issue #131

### DIFF
--- a/src/Boo.Lang.Compiler/Steps/MacroProcessing/BindAndApplyAttributes.cs
+++ b/src/Boo.Lang.Compiler/Steps/MacroProcessing/BindAndApplyAttributes.cs
@@ -263,11 +263,6 @@ namespace Boo.Lang.Compiler.Steps.MacroProcessing
 			VisitTypeDefinition(node);
 		}
 
-		override public void OnBlock(Block node)
-		{
-			// No need to visit blocks
-		}
-
 		override public void OnAttribute(Ast.Attribute attribute)
 		{
 			if (null != attribute.Entity)

--- a/src/Boo.Lang.Extensions/Attributes/DefaultAttribute.boo
+++ b/src/Boo.Lang.Extensions/Attributes/DefaultAttribute.boo
@@ -88,6 +88,10 @@ public class DefaultAttribute(Boo.Lang.Compiler.AbstractAstAttribute):
 		if method is not null:
 			method.Body.Statements.Insert(0, assignIfNull)
 		else:
-			property = cast(Property, parent)
-			if property.Setter is not null:
-				property.Setter.Body.Statements.Insert(0, assignIfNull)
+			lambda = (parent as BlockExpression)
+			if lambda is not null:
+				lambda.Body.Statements.Insert(0, assignIfNull)
+			else:
+				property = cast(Property, parent)
+				if property.Setter is not null:
+					property.Setter.Body.Statements.Insert(0, assignIfNull)

--- a/src/Boo.Lang.Extensions/Attributes/RequiredAttribute.boo
+++ b/src/Boo.Lang.Extensions/Attributes/RequiredAttribute.boo
@@ -52,17 +52,20 @@ class RequiredAttribute(Boo.Lang.Compiler.AbstractAstAttribute):
 		
 		parameter = node as ParameterDeclaration
 		if parameter is not null:			
-			method as Method = TargetMethod(parameter)
-			method.Body.Insert(0, BuildAssertion(parameter.Name))
+			body as Block = TargetMethodBody(parameter)
+			body.Insert(0, BuildAssertion(parameter.Name))
 			return
 		
 		property = node as Property
 		CheckProperty property
 		property.Setter.Body.Insert(0, BuildAssertion('value'))
 		
-	private def TargetMethod(parameter as ParameterDeclaration):
+	private def TargetMethodBody(parameter as ParameterDeclaration) as Block:
 		method = parameter.ParentNode as Method
 		return method if method is not null
+		
+		lambda = parameter.ParentNode as BlockExpression
+		return lambda.Body if lambda is not null
 		
 		property = parameter.ParentNode as Property
 		CheckProperty property


### PR DESCRIPTION
Ensuring that the BindAndApplyAttributes visitor can reach attributes
declared on closures, to fix an internal compiler error.
Ensuring that all applicable attributes in Boo.Lang.Extensions support
closure parameters.
